### PR TITLE
Use as_json before to_json in examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,8 +84,8 @@ Render a form that will be automatically posted when the U2F device reponds.
 
 ```javascript
 // render requests from server into Javascript format
-var registerRequests = <%= @registration_requests.to_json.html_safe %>;
-var signRequests = <%= @sign_requests.to_json.html_safe %>;
+var registerRequests = <%= @registration_requests.as_json.to_json.html_safe %>;
+var signRequests = <%= @sign_requests.as_json.to_json.html_safe %>;
 
 u2f.register(registerRequests, signRequests, function(registerResponse) {
   var form, reg;
@@ -160,7 +160,7 @@ Render a form that will be automatically posted when the U2F device reponds.
 
 ```javascript
 // render requests from server into Javascript format
-var signRequests = <%= @sign_requests.to_json.html_safe %>;
+var signRequests = <%= @sign_requests.as_json.to_json.html_safe %>;
 
 u2f.sign(signRequests, function(signResponse) {
   var form, reg;


### PR DESCRIPTION
When building [my implementation](https://github.com/konklone/konklone.com/pull/144), I got an exception thrown when calling `to_json`  on the `registration_requests` and `signing_requests` objects. I needed to first call `as_json` to convert the object into a dict suitable for serialization, and then call `to_json` to turn it into a real JSON string.

I'm not 100% sure of the reason for the environment difference, but it probably has to do with me doing this in Sinatra, rather than Rails.