### PR TITLE
Use base64 decoding in README example

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,7 +190,8 @@ def create
 
   begin
     u2f.authenticate!(session[:challenges], response,
-                      registration.public_key, registration.counter)
+                      Base64.decode64(registration.public_key), 
+                      registration.counter)
   rescue U2F::Error => e
     return "Unable to authenticate: <%= e.class.name %>"
   ensure


### PR DESCRIPTION
First things first: thanks for this library. Made it super-easy to build a u2f demo app.

Next: I tried implementing a small sample app based on Cuba, following the guide in the README. Turns out, the code is slightly wrong (outdated?) and base64-decoding of the public key is necessary (just as in the [Rails example](https://github.com/castle/ruby-u2f/blob/master/example/app/controllers/authentications.rb#L21)), so I went ahead and fixed it.