### PR TITLE
Fix public_key validation

### DIFF
--- a/lib/u2f/u2f.rb
+++ b/lib/u2f/u2f.rb
@@ -140,7 +140,7 @@ module U2F
     #   - +PublicKeyDecodeError+:: if the +key+ argument is incorrect
     #
     def self.public_key_pem(key)
-      fail PublicKeyDecodeError unless key.length == 65 || key[0] == "\x04"
+      fail PublicKeyDecodeError unless key.length == 65 && key[0] == "\x04"
       # http://tools.ietf.org/html/rfc5480
       der = OpenSSL::ASN1::Sequence([
         OpenSSL::ASN1::Sequence([

--- a/spec/lib/u2f_spec.rb
+++ b/spec/lib/u2f_spec.rb
@@ -117,8 +117,17 @@ describe U2F do
       end
     end
 
-    context 'with incorrect key' do
-      let(:public_key) { U2F.urlsafe_decode64('NW5jdzdnODV3dm9nNzU4d2duNTd3') }
+    context 'with invalid key' do
+      let(:public_key) { U2F.urlsafe_decode64('YV6FVSmH0ObY1cBRCsYJZ/CXF1gKsL+DW46rMfpeymtDZted2Ut2BraszUK1wg1+YJ4Bxt6r24WHNUYqKgeaSq8=') }
+      it 'fails when first byte of the key is not 0x04' do
+        expect {
+          U2F::U2F.public_key_pem public_key
+        }.to raise_error(U2F::PublicKeyDecodeError)
+      end
+    end
+
+    context 'with truncated key' do
+      let(:public_key) { U2F.urlsafe_decode64('BJhSPkR3Rmgl') }
       it 'fails when key is to short' do
         expect {
           U2F::U2F.public_key_pem public_key


### PR DESCRIPTION
The spec says that the public key *is always* 65 bytes. The current check validates that it is *either* 65 bytes or starts with `\x04`. I think this was supposed to be a `&&` instead of a `||`. I'd honestly rather get rid of the `\x04` check since I can't find anything that specifies that the key must start with that byte, though all the examples I've seen have.