### PR TITLE
Let #as_json accept optional options hash

### DIFF
--- a/lib/u2f/request_base.rb
+++ b/lib/u2f/request_base.rb
@@ -2,7 +2,7 @@ module U2F
   module RequestBase
     attr_accessor :version, :challenge, :app_id
 
-    def as_json
+    def as_json(options = {})
       {
         version: version,
         challenge: challenge,

--- a/lib/u2f/sign_request.rb
+++ b/lib/u2f/sign_request.rb
@@ -9,7 +9,7 @@ module U2F
       @app_id = app_id
     end
 
-    def as_json
+    def as_json(options = {})
       super.merge(keyHandle: key_handle)
     end
   end


### PR DESCRIPTION
Looks like ActiveSupport passes an options hash to `#as_json` as well as `#to_json`. This PR lets `#as_json` acception this argument so it doesn't need to be called explicitly.

This addresses an issue mentioned in https://github.com/castle/ruby-u2f/pull/6