### PR TITLE
Catch OpenSSL errors when verifying signatures

### DIFF
--- a/lib/u2f/register_response.rb
+++ b/lib/u2f/register_response.rb
@@ -95,7 +95,11 @@ module U2F
         public_key_raw
       ].join
 
-      parsed_certificate.public_key.verify(::U2F::DIGEST.new, signature, data)
+      begin
+        parsed_certificate.public_key.verify(::U2F::DIGEST.new, signature, data)
+      rescue OpenSSL::PKey::PKeyError
+        false
+      end
     end
 
     private

--- a/lib/u2f/sign_response.rb
+++ b/lib/u2f/sign_response.rb
@@ -46,7 +46,12 @@ module U2F
       ].join
 
       public_key = OpenSSL::PKey.read(public_key_pem)
-      public_key.verify(::U2F::DIGEST.new, signature, data)
+
+      begin
+        public_key.verify(::U2F::DIGEST.new, signature, data)
+      rescue OpenSSL::PKey::PKeyError
+        false
+      end
     end
   end
 end

--- a/spec/lib/register_response_spec.rb
+++ b/spec/lib/register_response_spec.rb
@@ -68,4 +68,17 @@ describe U2F::RegisterResponse do
     subject { register_response.verify(app_id) }
     it { is_expected.to be_truthy }
   end
+
+  describe '#verify with wrong app_id' do
+    subject { register_response.verify("other app") }
+    it { is_expected.to be_falsey }
+  end
+
+  describe '#verify with corrupted signature' do
+    subject { register_response }
+    it "returns falsey" do
+      allow(subject).to receive(:signature).and_return("bad signature")
+      expect(subject.verify(app_id)).to be_falsey
+    end
+  end
 end

--- a/spec/lib/sign_response_spec.rb
+++ b/spec/lib/sign_response_spec.rb
@@ -6,6 +6,7 @@ describe U2F::SignResponse do
   let(:device) { U2F::FakeU2F.new(app_id) }
   let(:json_response) { device.sign_response(challenge) }
   let(:sign_response) { U2F::SignResponse.load_from_json json_response }
+  let(:public_key_pem) { U2F::U2F.public_key_pem(device.origin_public_key_raw) }
 
   describe '#counter' do
     subject { sign_response.counter }
@@ -15,5 +16,23 @@ describe U2F::SignResponse do
   describe '#user_present?' do
     subject { sign_response.user_present? }
     it { is_expected.to be true }
+  end
+
+  describe '#verify with correct app id' do
+    subject { sign_response.verify(app_id, public_key_pem) }
+    it { is_expected.to be_truthy}
+  end
+
+  describe '#verify with wrong app id' do
+    subject { sign_response.verify("other app", public_key_pem) }
+    it { is_expected.to be_falsey }
+  end
+
+  describe '#verify with corrupted signature' do
+    subject { sign_response }
+    it "returns falsey" do
+      allow(subject).to receive(:signature).and_return("bad signature")
+      expect(subject.verify(app_id, public_key_pem)).to be_falsey
+    end
   end
 end


### PR DESCRIPTION
We've been noticing some `OpenSSL::PKey::PKeyError` errors since shipping U2F support. I haven't figured out the root cause of these errors yet, but I think this library should be catching them. This PR adds rescue blocks when verifying public key signatures.