### PR TITLE
Use byteslice instead of [] for slicing Strings

### DIFF
--- a/lib/u2f/sign_response.rb
+++ b/lib/u2f/sign_response.rb
@@ -19,7 +19,7 @@ module U2F
     # Counter value that the U2F token increments every time it performs an
     # authentication operation
     def counter
-      signature_data[1..4].unpack('N').first
+      signature_data.byteslice(1, 4).unpack('N').first
     end
 
     ##
@@ -32,7 +32,7 @@ module U2F
     ##
     # If user presence was verified
     def user_present?
-      signature_data[0].unpack('C').first == 1
+      signature_data.byteslice(0).unpack('C').first == 1
     end
 
     ##

--- a/lib/u2f/u2f.rb
+++ b/lib/u2f/u2f.rb
@@ -140,7 +140,7 @@ module U2F
     #   - +PublicKeyDecodeError+:: if the +key+ argument is incorrect
     #
     def self.public_key_pem(key)
-      fail PublicKeyDecodeError unless key.length == 65 && key[0] == "\x04"
+      fail PublicKeyDecodeError unless key.bytesize == 65 && key.byteslice(0) == "\x04"
       # http://tools.ietf.org/html/rfc5480
       der = OpenSSL::ASN1::Sequence([
         OpenSSL::ASN1::Sequence([


### PR DESCRIPTION
We've been running into `CounterTooLowError` errors that don't make any sense and that got me looking at how the counter is parsed out of the SignResponse. The Gem gets it from `signature_data[1..4].unpack('N').first`. This looks bad at first because `signature_data[1..4]` could return more than four bytes or the wrong bytes if `signature_data` weren't ASCII encoded. Luckily, `Base64.urlsafe_decode64` always returns an ASCII encoded String as far as I can tell. Still, I think it's a bit of a smell to be using `String#[]` for slicing up binary data. This PR replaces a few `String#[]` calls with `String#byteslice`.