### PR TITLE
Handle case where device counter is 0

### DIFF
--- a/lib/u2f/u2f.rb
+++ b/lib/u2f/u2f.rb
@@ -60,7 +60,9 @@ module U2F
       fail UserNotPresentError unless response.user_present?
 
       unless response.counter > registration_counter
-        fail CounterTooLowError
+        unless response.counter == 0 && registration_counter == 0
+          fail CounterTooLowError
+        end
       end
     end
 


### PR DESCRIPTION
The first time a user authenticates with a brand new security key, the counter from the database will be `0` and the counter from the SignResponse will be `0`. This will cause a `CounterTooLowError` to be thrown in `U2F#authenticate!`. This seems like a bit of a design flaw in the protocol because it prevents implementors from doing a simple `>` check like this Gem does.

The alternative fix to this PR would be to have [`U2F::Registration#counter`](https://github.com/castle/ruby-u2f/blob/0e78a49a62e07a9dff7a0cb3c6c8fd4a2e793dc1/lib/u2f/registration.rb#L12-L14) return `-1` by default. That could be a breaking change though, depending on how people store registrations in their databases (signed vs. unsigned int).