### PR TITLE
Add validation to load_from_json methods

### DIFF
--- a/lib/u2f/register_response.rb
+++ b/lib/u2f/register_response.rb
@@ -13,8 +13,12 @@ module U2F
     KEY_HANDLE_OFFSET = KEY_HANDLE_LENGTH_OFFSET + KEY_HANDLE_LENGTH_LENGTH
 
     def self.load_from_json(json)
-      # TODO: validate
-      data = JSON.parse(json)
+      fail ClientDataTypeError unless json.respond_to? :to_str
+      begin
+        data = JSON.parse(json)
+      rescue JSON::ParserError
+        fail ClientDataTypeError
+      end
 
       if data['errorCode'] && data['errorCode'] > 0
         fail RegistrationError, :code => data['errorCode']

--- a/lib/u2f/sign_response.rb
+++ b/lib/u2f/sign_response.rb
@@ -3,7 +3,13 @@ module U2F
     attr_accessor :client_data, :client_data_json, :key_handle, :signature_data
 
     def self.load_from_json(json)
-      data = ::JSON.parse(json)
+      fail ClientDataTypeError unless json.respond_to? :to_str
+      begin
+        data = JSON.parse(json)
+      rescue JSON::ParserError
+        fail ClientDataTypeError
+      end
+
       instance = new
       instance.client_data_json =
         ::U2F.urlsafe_decode64(data['clientData'])

--- a/spec/lib/register_response_spec.rb
+++ b/spec/lib/register_response_spec.rb
@@ -17,6 +17,24 @@ describe U2F::RegisterResponse do
     U2F::RegisterResponse.load_from_json(registration_data_json)
   end
 
+  context 'with nil value' do
+    let(:registration_data_json) { nil }
+    it 'raises ClientDataTypeError' do
+      expect {
+        register_response
+      }.to raise_error(U2F::ClientDataTypeError)
+    end
+  end
+
+  context 'with empty string' do
+    let(:registration_data_json) { "" }
+    it 'raises ClientDataTypeError' do
+      expect {
+        register_response
+      }.to raise_error(U2F::ClientDataTypeError)
+    end
+  end
+
   context 'with error response' do
     let(:registration_data_json) { error_response }
     it 'raises RegistrationError with code' do

--- a/spec/lib/sign_response_spec.rb
+++ b/spec/lib/sign_response_spec.rb
@@ -4,9 +4,29 @@ describe U2F::SignResponse do
   let(:app_id) { 'http://demo.example.com' }
   let(:challenge) { U2F.urlsafe_encode64(SecureRandom.random_bytes(32)) }
   let(:device) { U2F::FakeU2F.new(app_id) }
-  let(:json_response) { device.sign_response(challenge) }
-  let(:sign_response) { U2F::SignResponse.load_from_json json_response }
   let(:public_key_pem) { U2F::U2F.public_key_pem(device.origin_public_key_raw) }
+  let(:sign_data_json) { device.sign_response(challenge) }
+  let(:sign_response) do
+    U2F::SignResponse.load_from_json(sign_data_json)
+  end
+
+  context 'with nil value' do
+    let(:sign_data_json) { nil }
+    it 'raises ClientDataTypeError' do
+      expect {
+        sign_response
+      }.to raise_error(U2F::ClientDataTypeError)
+    end
+  end
+
+  context 'with empty string' do
+    let(:sign_data_json) { "" }
+    it 'raises ClientDataTypeError' do
+      expect {
+        sign_response
+      }.to raise_error(U2F::ClientDataTypeError)
+    end
+  end
 
   describe '#counter' do
     subject { sign_response.counter }


### PR DESCRIPTION
Hi,

I added validation to the load_from_json methods. I check for for a string-like object and catch the JSON::ParserError for invalid format. Afterwards a ClientDataTypeError exceptions gets thrown.
Test are also included.

Chris