### PR TITLE
Only check bit 0 when checking user-presence

### DIFF
--- a/lib/u2f/sign_response.rb
+++ b/lib/u2f/sign_response.rb
@@ -29,10 +29,15 @@ module U2F
       signature_data.byteslice(5..-1)
     end
 
+    # Bit 0 being set to 1 indicates that the user is present. A different value
+    # of Bit 0, as well as Bits 1 through 7, are reserved for future use.
+    USER_PRESENCE_MASK = 0b00000001
+
     ##
     # If user presence was verified
     def user_present?
-      signature_data.byteslice(0).unpack('C').first == 1
+      byte = signature_data.byteslice(0).unpack('C').first
+      byte & USER_PRESENCE_MASK == 1
     end
 
     ##


### PR DESCRIPTION
A whole byte is used in the sign-response for indicating user-presence. Bit 0 of this byte indicates user presence and the rest of the bits are reserved. Some U2F implementations are currently using higher order bits to indicate if the sign-response came via NFC. This PR updates `SignResponse#user_present?` to only check bit 0.

[spec](https://fidoalliance.org/specs/fido-u2f-v1.0-nfc-bt-amendment-20150514/fido-u2f-raw-message-formats.html#h3_authentication-response-message-success)
/cc @juanlang