### PR TITLE
Make some updates for v1.1 JS API

### DIFF
--- a/lib/u2f/register_request.rb
+++ b/lib/u2f/register_request.rb
@@ -1,10 +1,17 @@
 module U2F
   class RegisterRequest
     include RequestBase
+    attr_accessor :challenge
 
-    def initialize(challenge, app_id)
+    def initialize(challenge)
       @challenge = challenge
-      @app_id = app_id
+    end
+
+    def as_json(options = {})
+      {
+        version: version,
+        challenge: challenge
+      }
     end
   end
 end

--- a/lib/u2f/request_base.rb
+++ b/lib/u2f/request_base.rb
@@ -1,14 +1,6 @@
 module U2F
   module RequestBase
-    attr_accessor :version, :challenge, :app_id
-
-    def as_json(options = {})
-      {
-        version: version,
-        challenge: challenge,
-        appId: app_id
-      }
-    end
+    attr_accessor :version
 
     def to_json(options = {})
       ::JSON.pretty_generate(as_json, options)

--- a/lib/u2f/sign_request.rb
+++ b/lib/u2f/sign_request.rb
@@ -3,14 +3,15 @@ module U2F
     include RequestBase
     attr_accessor :key_handle
 
-    def initialize(key_handle, challenge, app_id)
+    def initialize(key_handle)
       @key_handle = key_handle
-      @challenge = challenge
-      @app_id = app_id
     end
 
     def as_json(options = {})
-      super.merge(keyHandle: key_handle)
+      {
+        version: version,
+        keyHandle: key_handle
+      }
     end
   end
 end

--- a/lib/u2f/u2f.rb
+++ b/lib/u2f/u2f.rb
@@ -21,7 +21,7 @@ module U2F
     def authentication_requests(key_handles)
       key_handles = [key_handles] unless key_handles.is_a? Array
       key_handles.map do |key_handle|
-        SignRequest.new(key_handle, challenge, app_id)
+        SignRequest.new(key_handle)
       end
     end
 
@@ -41,13 +41,11 @@ module U2F
     #   - +UserNotPresentError+:: if the user wasn't present during the authentication
     #   - +CounterTooLowError+:: if there is a counter mismatch between the registered one and the one in the response.
     #
-    def authenticate!(challenges, response, registration_public_key,
+    def authenticate!(challenge, response, registration_public_key,
                       registration_counter)
-      # Handle both single and Array input
-      challenges = [challenges] unless challenges.is_a? Array
 
       # TODO: check that it's the correct key_handle as well
-      unless challenges.include?(response.client_data.challenge)
+      unless challenge == response.client_data.challenge
         fail NoMatchingRequestError
       end
 
@@ -84,7 +82,7 @@ module U2F
     #
     def registration_requests
       # TODO: generate a request for each supported version
-      [RegisterRequest.new(challenge, @app_id)]
+      [RegisterRequest.new(challenge)]
     end
 
     ##

--- a/spec/lib/register_request_spec.rb
+++ b/spec/lib/register_request_spec.rb
@@ -1,11 +1,10 @@
 require 'spec_helper'
 
 describe U2F::RegisterRequest do
-  let(:app_id) { 'http://example.com' }
   let(:challenge) { 'fEnc9oV79EaBgK5BoNERU5gPKM2XGYWrz4fUjgc0Q7g' }
 
   let(:sign_request) do
-    U2F::RegisterRequest.new(challenge, app_id)
+    U2F::RegisterRequest.new(challenge)
   end
 
   describe '#to_json' do
@@ -13,7 +12,6 @@ describe U2F::RegisterRequest do
     it do
       is_expected.to match_json_expression(
         version: String,
-        appId: String,
         challenge: String
       )
     end

--- a/spec/lib/register_response_spec.rb
+++ b/spec/lib/register_response_spec.rb
@@ -12,7 +12,7 @@ describe U2F::RegisterResponse do
     device.register_response(challenge).gsub(" ", "")
   end
   let(:error_response) { device.register_response(challenge, error = true) }
-  let(:registration_request) { U2F::RegisterRequest.new(challenge, app_id) }
+  let(:registration_request) { U2F::RegisterRequest.new(challenge) }
   let(:register_response) do
     U2F::RegisterResponse.load_from_json(registration_data_json)
   end

--- a/spec/lib/sign_request_spec.rb
+++ b/spec/lib/sign_request_spec.rb
@@ -1,13 +1,11 @@
 require 'spec_helper'
 
 describe U2F::SignRequest do
-  let(:app_id) { 'http://example.com' }
-  let(:challenge) { 'fEnc9oV79EaBgK5BoNERU5gPKM2XGYWrz4fUjgc0Q7g' }
   let(:key_handle) do
     'CTUayZo8hCBeC-sGQJChC0wW-bBg99bmOlGCgw8XGq4dLsxO3yWh9mRYArZxocP5hBB1pEGB3bbJYiM-5acc5w=='
   end
   let(:sign_request) do
-    U2F::SignRequest.new(key_handle, challenge, app_id)
+    U2F::SignRequest.new(key_handle)
   end
 
   describe '#to_json' do
@@ -15,8 +13,6 @@ describe U2F::SignRequest do
     it do
       is_expected.to match_json_expression(
         version: String,
-        appId: String,
-        challenge: String,
         keyHandle: String
       )
     end

--- a/spec/lib/u2f_spec.rb
+++ b/spec/lib/u2f_spec.rb
@@ -21,7 +21,7 @@ describe U2F do
     U2F::SignResponse.load_from_json sign_response_json
   end
   let(:sign_request) do
-    U2F::SignRequest.new(key_handle, auth_challenge, app_id)
+    U2F::SignRequest.new(key_handle)
   end
 
   describe '#authentication_requests' do


### PR DESCRIPTION
Some breaking changes are coming in the 1.1 version of the JavaScript API (I guess Google doesn't use semantic versioning). These changes include:

- One appId value per request, instead of per-challenge appId values.
- For sign requests, a single challenge value, instead of a per-key handle challenge.
- signRequests are now renamed registeredKeys (since they don't have appIds or challenges anymore.)

You can see the new API [here](https://github.com/google/u2f-ref-code/blob/29833edf19fe27da2334c4af91b4d0358137f25d/u2f-gae-demo/war/js/u2f-api.js).

I updated `SignRequest` and `RegisterRequest` to be used with these new APIs. I can't get tests working locally, because of some vague OpenSSL errors. Not sure what to do about that.

I imagine we'll want a new major version of this gem because of the breaking changes to the API. 