### PR TITLE
Code cleanup

### DIFF
--- a/lib/u2f/client_data.rb
+++ b/lib/u2f/client_data.rb
@@ -3,7 +3,7 @@ module U2F
   # A representation of ClientData, chapter 7
   # http://fidoalliance.org/specs/fido-u2f-raw-message-formats-v1.0-rd-20141008.pdf
   class ClientData
-    REGISTRATION_TYP = 'navigator.id.finishEnrollment'.freeze
+    REGISTRATION_TYP   = 'navigator.id.finishEnrollment'.freeze
     AUTHENTICATION_TYP = 'navigator.id.getAssertion'.freeze
 
     attr_accessor :typ, :challenge, :origin

--- a/lib/u2f/client_data.rb
+++ b/lib/u2f/client_data.rb
@@ -3,11 +3,11 @@ module U2F
   # A representation of ClientData, chapter 7
   # http://fidoalliance.org/specs/fido-u2f-raw-message-formats-v1.0-rd-20141008.pdf
   class ClientData
-    REGISTRATION_TYP   = "navigator.id.finishEnrollment".freeze
-    AUTHENTICATION_TYP = "navigator.id.getAssertion".freeze
+    REGISTRATION_TYP = 'navigator.id.finishEnrollment'.freeze
+    AUTHENTICATION_TYP = 'navigator.id.getAssertion'.freeze
 
     attr_accessor :typ, :challenge, :origin
-    alias_method :type, :typ
+    alias type typ
 
     def registration?
       typ == REGISTRATION_TYP

--- a/lib/u2f/errors.rb
+++ b/lib/u2f/errors.rb
@@ -12,14 +12,16 @@ module U2F
   class AuthenticationFailedError < Error; end
   class UserNotPresentError < Error;end
 
+  # This error represents various potential errors that a user can come across
+  # while attempting to register.
   class RegistrationError < Error
     CODES = {
-      1 => "OTHER_ERROR",
-      2 => "BAD_REQUEST",
-      3 => "CONFIGURATION_UNSUPPORTED",
-      4 => "DEVICE_INELIGIBLE",
-      5 => "TIMEOUT"
-    }
+      1 => 'OTHER_ERROR',
+      2 => 'BAD_REQUEST',
+      3 => 'CONFIGURATION_UNSUPPORTED',
+      4 => 'DEVICE_INELIGIBLE',
+      5 => 'TIMEOUT'
+    }.freeze
 
     attr_reader :code
 

--- a/lib/u2f/fake_u2f.rb
+++ b/lib/u2f/fake_u2f.rb
@@ -1,5 +1,6 @@
+# This class is for mocking a U2F device for testing purposes.
 class U2F::FakeU2F
-  CURVE_NAME   = "prime256v1".freeze
+  CURVE_NAME = 'prime256v1'.freeze
 
   attr_accessor :app_id, :counter, :key_handle_raw, :cert_subject
 
@@ -17,7 +18,7 @@ class U2F::FakeU2F
     @app_id = app_id
     @counter = options.fetch(:counter, 0)
     @key_handle_raw = options.fetch(:key_handle, SecureRandom.random_bytes(32))
-    @cert_subject = options.fetch(:cert_subject, "/CN=U2FTest")
+    @cert_subject = options.fetch(:cert_subject, '/CN=U2FTest')
   end
 
   # A registerResponse hash as returned by the u2f.register JavaScript API.
@@ -28,12 +29,12 @@ class U2F::FakeU2F
   # Returns a JSON encoded Hash String.
   def register_response(challenge, error = false)
     if error
-      JSON.dump(:errorCode => 4)
+      JSON.dump(errorCode: 4)
     else
       client_data_json = client_data(U2F::ClientData::REGISTRATION_TYP, challenge)
       JSON.dump(
-        :registrationData => reg_registration_data(client_data_json),
-        :clientData => U2F.urlsafe_encode64(client_data_json)
+        registrationData: reg_registration_data(client_data_json),
+        clientData: U2F.urlsafe_encode64(client_data_json)
       )
     end
   end
@@ -46,9 +47,9 @@ class U2F::FakeU2F
   def sign_response(challenge)
     client_data_json = client_data(U2F::ClientData::AUTHENTICATION_TYP, challenge)
     JSON.dump(
-      :clientData => U2F.urlsafe_encode64(client_data_json),
-      :keyHandle => U2F.urlsafe_encode64(key_handle_raw),
-      :signatureData => auth_signature_data(client_data_json)
+      clientData: U2F.urlsafe_encode64(client_data_json),
+      keyHandle: U2F.urlsafe_encode64(key_handle_raw),
+      signatureData: auth_signature_data(client_data_json)
     )
   end
 
@@ -115,7 +116,7 @@ class U2F::FakeU2F
         1, # User present
         self.counter += 1,
         auth_signature(client_data_json)
-      ].pack("CNA*")
+      ].pack('CNA*')
     )
   end
 
@@ -130,7 +131,7 @@ class U2F::FakeU2F
       1, # User present
       counter,
       U2F::DIGEST.digest(client_data_json)
-    ].pack("A32CNA32")
+    ].pack('A32CNA32')
 
     origin_key.sign(U2F::DIGEST.new, data)
   end
@@ -144,9 +145,9 @@ class U2F::FakeU2F
   # Returns a JSON encoded Hash String.
   def client_data(typ, challenge)
     JSON.dump(
-      :challenge => challenge,
-      :origin    => app_id,
-      :typ       => typ
+      challenge: challenge,
+      origin: app_id,
+      typ: typ
     )
   end
 
@@ -183,7 +184,7 @@ class U2F::FakeU2F
   #
   # Returns a OpenSSL::PKey::EC instance.
   def generate_ec_key
-    OpenSSL::PKey::EC.new().tap do |ec|
+    OpenSSL::PKey::EC.new.tap do |ec|
       ec.group = OpenSSL::PKey::EC::Group.new(CURVE_NAME)
       ec.generate_key
       # https://bugs.ruby-lang.org/issues/8177

--- a/lib/u2f/register_request.rb
+++ b/lib/u2f/register_request.rb
@@ -7,7 +7,7 @@ module U2F
       @challenge = challenge
     end
 
-    def as_json(options = {})
+    def as_json(_options = {})
       {
         version: version,
         challenge: challenge

--- a/lib/u2f/register_response.rb
+++ b/lib/u2f/register_response.rb
@@ -17,7 +17,7 @@ module U2F
       data = JSON.parse(json)
 
       if data['errorCode'] && data['errorCode'] > 0
-        fail RegistrationError, :code => data['errorCode']
+        raise RegistrationError, code: data['errorCode']
       end
 
       instance = new

--- a/lib/u2f/registration.rb
+++ b/lib/u2f/registration.rb
@@ -2,7 +2,9 @@ module U2F
   ##
   # A representation of a registered U2F device
   class Registration
-    attr_accessor :key_handle, :public_key, :certificate, :counter
+    attr_writer :counter
+    attr_accessor :key_handle, :public_key, :certificate
+
     def initialize(key_handle, public_key, certificate)
       @key_handle = key_handle
       @public_key = public_key

--- a/lib/u2f/u2f.rb
+++ b/lib/u2f/u2f.rb
@@ -46,20 +46,20 @@ module U2F
 
       # TODO: check that it's the correct key_handle as well
       unless challenge == response.client_data.challenge
-        fail NoMatchingRequestError
+        raise NoMatchingRequestError
       end
 
-      fail ClientDataTypeError unless response.client_data.authentication?
+      raise ClientDataTypeError unless response.client_data.authentication?
 
       pem = U2F.public_key_pem(registration_public_key)
 
-      fail AuthenticationFailedError unless response.verify(app_id, pem)
+      raise AuthenticationFailedError unless response.verify(app_id, pem)
 
-      fail UserNotPresentError unless response.user_present?
+      raise UserNotPresentError unless response.user_present?
 
       unless response.counter > registration_counter
-        unless response.counter == 0 && registration_counter == 0
-          fail CounterTooLowError
+        unless response.counter.zero? && registration_counter.zero?
+          raise CounterTooLowError
         end
       end
     end
@@ -106,9 +106,9 @@ module U2F
         chg == response.client_data.challenge
       end
 
-      fail UnmatchedChallengeError unless challenge
+      raise UnmatchedChallengeError unless challenge
 
-      fail ClientDataTypeError unless response.client_data.registration?
+      raise ClientDataTypeError unless response.client_data.registration?
 
       # Validate public key
       U2F.public_key_pem(response.public_key_raw)
@@ -118,14 +118,13 @@ module U2F
       #   fail AttestationVerificationError
       # end
 
-      fail AttestationSignatureError unless response.verify(app_id)
+      raise AttestationSignatureError unless response.verify(app_id)
 
-      registration = Registration.new(
+      Registration.new(
         response.key_handle,
         response.public_key,
         response.certificate
       )
-      registration
     end
 
     ##

--- a/lib/version.rb
+++ b/lib/version.rb
@@ -1,3 +1,3 @@
 module U2F
-  VERSION = '1.0.0'
+  VERSION = '1.0.0'.freeze
 end


### PR DESCRIPTION
I was looking through the code base and saw a fair number of either inefficient, old, or possibly dangerous lines of code so I corrected them. The main things that I did were:

* Replaced unnecessary double quotes with single quotes
* Converted Hashrocket style hashes to Ruby 1.9 style hashes (as the target version is 2.0+)
* Freezed any assignments to constants
* Replaced `fail` with `raise`. The rationale for that being [here](https://github.com/bbatsov/ruby-style-guide/issues/512).

Explanations for other changes

* client_data.rb line 10: `alias` is generally now prefered over `alias_method` in class bodies.
* register_request line 10: While `options` is a required parameter, as it is unused, it is idiomatic to name it `_options` to signify that it is unused. 
* registration line 6: As `Registration#counter` is explicitly defined, it is clearer to have `counter` be an `attr_writer` instead of `attr_accessor`.
