### PR TITLE
Example and doc fixups

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,8 +166,8 @@ Render a form that will be automatically posted when the U2F device reponds.
 ```javascript
 // render requests from server into Javascript format
 var signRequests = <%= @sign_requests.to_json.html_safe %>;
-var challenge = #{@challenge.to_json.html_safe};
-var appId = #{@app_id.to_json.html_safe};
+var challenge = <%= @challenge.to_json.html_safe %>;
+var appId = <%= @app_id.to_json.html_safe %>;
 
 u2f.sign(appId, challenge, signRequests, function(signResponse) {
   var form, reg;

--- a/README.md
+++ b/README.md
@@ -40,6 +40,8 @@ The U2F library has two major tasks:
 
 Each task starts by generating a challenge on the server, which is rendered to a web view, read by the browser APIs and transmitted to the plugged in U2F devices for verification. The U2F device responds and triggers a callback in the browser, and a form is posted back to your server where you verify the challenge and store the U2F device information to your database.
 
+Note that ordinarily, each user will have one or more U2F registrations (as it's a common usage pattern for users to have more than one U2F device -- for example one for regular use, and a second stored safely as a backup). While it's omitted from examples here for brevity, a new registration should typically be associated with the particular user registering. Likewise, when authenticating, queries over "all registrations" should actually be scoped to registrations associated with the particular user being authenticated.
+
 You'll need an instance of `U2F::U2F`, which is conveniently placed in an [instance method](https://github.com/castle/ruby-u2f/blob/API_v1_1/example/app/helpers/helpers.rb) on the controller. The initializer takes an **App ID** as argument.
 
 ```ruby
@@ -67,6 +69,8 @@ def new
   key_handles = Registration.map(&:key_handle)
   @sign_requests = u2f.authentication_requests(key_handles)
 
+  @app_id = u2f.app_id
+
   render 'registrations/new'
 end
 ```
@@ -82,10 +86,11 @@ Render a form that will be automatically posted when the U2F device reponds.
 
 ```javascript
 // render requests from server into Javascript format
-var registerRequests = <%= @registration_requests.as_json.to_json.html_safe %>;
+var appId = <%= @app_id.to_json.html_safe %>
+var registerRequests = <%= @registration_requests.to_json.html_safe %>;
 var signRequests = <%= @sign_requests.as_json.to_json.html_safe %>;
 
-u2f.register(registerRequests, signRequests, function(registerResponse) {
+u2f.register(appId, registerRequests, signRequests, function(registerResponse) {
   var form, reg;
 
   if (registerResponse.errorCode) {
@@ -138,10 +143,12 @@ def new
   return 'Need to register first' if key_handles.empty?
 
   # Generate SignRequests
+  @app_id = u2f.app_id
   @sign_requests = u2f.authentication_requests(key_handles)
+  @challenge = u2f.challenge
 
-  # Store challenges. We need them for the verification step
-  session[:challenges] = @sign_requests.map(&:challenge)
+  # Store challenge. We need it for the verification step
+  session[:challenge] = @challenge
 
   render 'authentications/new'
 end
@@ -158,9 +165,11 @@ Render a form that will be automatically posted when the U2F device reponds.
 
 ```javascript
 // render requests from server into Javascript format
-var signRequests = <%= @sign_requests.as_json.to_json.html_safe %>;
+var signRequests = <%= @sign_requests.to_json.html_safe %>;
+var challenge = #{@challenge.to_json.html_safe};
+var appId = #{@app_id.to_json.html_safe};
 
-u2f.sign(signRequests, function(signResponse) {
+u2f.sign(appId, challenge, signRequests, function(signResponse) {
   var form, reg;
 
   if (signResponse.errorCode) {
@@ -187,13 +196,13 @@ def create
   return 'Need to register first' unless registration
 
   begin
-    u2f.authenticate!(session[:challenges], response,
+    u2f.authenticate!(session[:challenge], response,
                       Base64.decode64(registration.public_key),
                       registration.counter)
   rescue U2F::Error => e
     return "Unable to authenticate: <%= e.class.name %>"
   ensure
-    session.delete(:challenges)
+    session.delete(:challenge)
   end
 
   registration.update(counter: response.counter)

--- a/example/Gemfile
+++ b/example/Gemfile
@@ -20,4 +20,4 @@ gem 'padrino', '0.12.4'
 # To enable https
 gem 'thin'
 
-gem 'u2f'#, path: '../.'
+gem 'u2f', '1.0.0'

--- a/example/Gemfile.lock
+++ b/example/Gemfile.lock
@@ -114,7 +114,7 @@ GEM
       polyglot (>= 0.3.1)
     tzinfo (1.2.2)
       thread_safe (~> 0.1)
-    u2f (0.2.0)
+    u2f (1.0.0)
     url_mount (0.2.1)
       rack
     uuidtools (2.1.5)
@@ -135,7 +135,4 @@ DEPENDENCIES
   padrino (= 0.12.4)
   rake
   thin
-  u2f
-
-BUNDLED WITH
-   1.12.3
+  u2f (= 1.0.0)

--- a/example/app/controllers/registrations.rb
+++ b/example/app/controllers/registrations.rb
@@ -6,6 +6,8 @@ U2FExample::App.controllers :registrations do
     key_handles = Registration.map(&:key_handle)
     @sign_requests = u2f.authentication_requests(key_handles)
 
+    @app_id = u2f.app_id
+
     render 'registrations/new'
   end
 

--- a/example/app/views/authentications/new.haml
+++ b/example/app/views/authentications/new.haml
@@ -19,6 +19,8 @@
 
 :javascript
   var signRequests = #{@sign_requests.to_json.html_safe};
+  var challenge = #{@challenge.to_json.html_safe};
+  var appId = #{@app_id.to_json.html_safe};
   var $waiting = document.getElementById('waiting');
   var $error = document.getElementById('error');
   var errorMap = {
@@ -33,8 +35,6 @@
     $error.style.display = 'block';
     $error.innerHTML = errorMap[code];
   };
-  var appId = signRequests[0].appId
-  var challenge = signRequests[0].challenge
 
   u2f.sign(appId, challenge, signRequests, function(signResponse) {
     var form, reg;

--- a/example/app/views/registrations/new.haml
+++ b/example/app/views/registrations/new.haml
@@ -17,6 +17,7 @@
   = hidden_field_tag :response
 
 :javascript
+  var appId = #{@app_id.to_json.html_safe};
   var registerRequests = #{@registration_requests.to_json.html_safe};
   var signRequests = #{@sign_requests.to_json.html_safe};
   var $waiting = document.getElementById('waiting');
@@ -33,7 +34,6 @@
     $error.style.display = 'block';
     $error.innerHTML = errorMap[code];
   };
-  var appId = registerRequests[0].appId
 
   u2f.register(appId, registerRequests, signRequests, function(registerResponse) {
     var form, reg;


### PR DESCRIPTION
This PR updates the example to work with the JS and Ruby APIs provided by version 1.0.0 of the gem. (This requires adjustments as the request objects no longer have separate appIds or challenges.)  This resolves issues #31, #32, and provides examples which serve as better models for what the reporter was trying to do in #34.

It also updates the Ruby and JS examples in the README to match the current codebase, and adds a note that in actual usage, registration objects would be associated with a particular user on creation, and subsequent queries for them would ordinarily be scoped to those associated with the particular user trying to authenticate.