### PR TITLE
Validate the JSON data in load

### DIFF
--- a/lib/u2f/register_response.rb
+++ b/lib/u2f/register_response.rb
@@ -21,7 +21,7 @@ module U2F
         raise RegistrationError, code: data['errorCode']
       end
 
-      if data['clientData'].blank? || data['registrationData'].blank?
+      if !data.key?('clientData') || !data.key?('registrationData')
         raise RegistrationError, code: BAD_REQUEST
       end
       

--- a/lib/u2f/register_response.rb
+++ b/lib/u2f/register_response.rb
@@ -11,7 +11,6 @@ module U2F
     KEY_HANDLE_LENGTH_LENGTH = 1
     KEY_HANDLE_LENGTH_OFFSET = PUBLIC_KEY_OFFSET + PUBLIC_KEY_LENGTH
     KEY_HANDLE_OFFSET = KEY_HANDLE_LENGTH_OFFSET + KEY_HANDLE_LENGTH_LENGTH
-    BAD_REQUEST = 2
 
     def self.load_from_json(json)
       # TODO: validate
@@ -22,7 +21,7 @@ module U2F
       end
 
       if !data.key?('clientData') || !data.key?('registrationData')
-        raise RegistrationError, code: BAD_REQUEST
+        raise RegistrationError, message: 'Invalid JSON'
       end
       
       instance = new

--- a/lib/u2f/register_response.rb
+++ b/lib/u2f/register_response.rb
@@ -21,9 +21,9 @@ module U2F
       end
 
       if !data.key?('clientData') || !data.key?('registrationData')
-        raise RegistrationError, 'Invalid JSON'
+        raise RegistrationError, message: 'Invalid JSON'
       end
-      
+
       instance = new
       instance.client_data_json =
         ::U2F.urlsafe_decode64(data['clientData'])

--- a/lib/u2f/register_response.rb
+++ b/lib/u2f/register_response.rb
@@ -21,7 +21,7 @@ module U2F
       end
 
       if !data.key?('clientData') || !data.key?('registrationData')
-        raise RegistrationError, message: 'Invalid JSON'
+        raise RegistrationError, 'Invalid JSON'
       end
       
       instance = new

--- a/lib/u2f/register_response.rb
+++ b/lib/u2f/register_response.rb
@@ -20,6 +20,10 @@ module U2F
         raise RegistrationError, code: data['errorCode']
       end
 
+      if data['clientData'].blank? || data['registrationData'].blank?
+        raise RegistrationError, code: 2
+      end
+      
       instance = new
       instance.client_data_json =
         ::U2F.urlsafe_decode64(data['clientData'])

--- a/lib/u2f/register_response.rb
+++ b/lib/u2f/register_response.rb
@@ -11,6 +11,7 @@ module U2F
     KEY_HANDLE_LENGTH_LENGTH = 1
     KEY_HANDLE_LENGTH_OFFSET = PUBLIC_KEY_OFFSET + PUBLIC_KEY_LENGTH
     KEY_HANDLE_OFFSET = KEY_HANDLE_LENGTH_OFFSET + KEY_HANDLE_LENGTH_LENGTH
+    BAD_REQUEST = 2
 
     def self.load_from_json(json)
       # TODO: validate
@@ -21,7 +22,7 @@ module U2F
       end
 
       if data['clientData'].blank? || data['registrationData'].blank?
-        raise RegistrationError, code: 2
+        raise RegistrationError, code: BAD_REQUEST
       end
       
       instance = new

--- a/lib/u2f/sign_response.rb
+++ b/lib/u2f/sign_response.rb
@@ -4,7 +4,7 @@ module U2F
 
     def self.load_from_json(json)
       data = ::JSON.parse(json)
-      if data['clientData'].nil? || data['keyHandle'].nil? || data['signatureData'].nil?
+      if data.key?('clientData') || data.key?('keyHandle') || data.key?('signatureData')
         raise Error, 'Missing required data'
       end
       

--- a/lib/u2f/sign_response.rb
+++ b/lib/u2f/sign_response.rb
@@ -4,10 +4,11 @@ module U2F
 
     def self.load_from_json(json)
       data = ::JSON.parse(json)
-      if data.key?('clientData') || data.key?('keyHandle') || data.key?('signatureData')
+      if !data.key?('clientData') || !data.key?('keyHandle') ||
+         !data.key?('signatureData')
         raise Error, 'Missing required data'
       end
-      
+
       instance = new
       instance.client_data_json =
         ::U2F.urlsafe_decode64(data['clientData'])

--- a/lib/u2f/sign_response.rb
+++ b/lib/u2f/sign_response.rb
@@ -4,6 +4,10 @@ module U2F
 
     def self.load_from_json(json)
       data = ::JSON.parse(json)
+      if data['clientData'].blank? || data['keyHandle'].blank? || data['signatureData'].blank?
+        raise Error, 'Missing required data'
+      end
+      
       instance = new
       instance.client_data_json =
         ::U2F.urlsafe_decode64(data['clientData'])

--- a/lib/u2f/sign_response.rb
+++ b/lib/u2f/sign_response.rb
@@ -4,7 +4,7 @@ module U2F
 
     def self.load_from_json(json)
       data = ::JSON.parse(json)
-      if data['clientData'].blank? || data['keyHandle'].blank? || data['signatureData'].blank?
+      if data['clientData'].nil? || data['keyHandle'].nil? || data['signatureData'].nil?
         raise Error, 'Missing required data'
       end
       

--- a/spec/lib/register_response_spec.rb
+++ b/spec/lib/register_response_spec.rb
@@ -34,7 +34,7 @@ describe U2F::RegisterResponse do
       expect {
         register_response
       }.to raise_error(U2F::RegistrationError) do |error|
-        expect(error.code).to eq(2)
+        expect(error.message).to eq('Invalid JSON')
       end
     end
   end

--- a/spec/lib/register_response_spec.rb
+++ b/spec/lib/register_response_spec.rb
@@ -28,6 +28,17 @@ describe U2F::RegisterResponse do
     end
   end
 
+  context 'with invalid response' do
+    let(:registration_data_json) { '{}' }
+    t 'raises RegistrationError with code' do
+      expect {
+        register_response
+      }.to raise_error(U2F::RegistrationError) do |error|
+        expect(error.code).to eq(2)
+      end
+    end
+  end
+  
   context 'with unpadded response' do
     let(:registration_data_json) { registration_data_json_without_padding }
     it 'does not raise "invalid base64" exception' do

--- a/spec/lib/register_response_spec.rb
+++ b/spec/lib/register_response_spec.rb
@@ -30,7 +30,7 @@ describe U2F::RegisterResponse do
 
   context 'with invalid response' do
     let(:registration_data_json) { '{}' }
-    t 'raises RegistrationError with code' do
+    it 'raises RegistrationError with code' do
       expect {
         register_response
       }.to raise_error(U2F::RegistrationError) do |error|

--- a/spec/lib/sign_response_spec.rb
+++ b/spec/lib/sign_response_spec.rb
@@ -8,6 +8,17 @@ describe U2F::SignResponse do
   let(:sign_response) { U2F::SignResponse.load_from_json json_response }
   let(:public_key_pem) { U2F::U2F.public_key_pem(device.origin_public_key_raw) }
 
+  context 'with invalid response' do
+    let(:json_response) { '{}' }
+    it 'raises error' do
+      expect {
+        sign_response
+      }.to raise_error(U2F::Error) do |error|
+        expect(error.message).to eq('Missing required data')
+      end
+    end
+  end
+  
   describe '#counter' do
     subject { sign_response.counter }
     it { is_expected.to be device.counter }


### PR DESCRIPTION
Check to make sure that the loaded JSON actually contains data in the keys we are going to use before we use them, to avoid runtime exceptions on Nil.