### PR TITLE
Drop support for ruby 2.2

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,7 +1,7 @@
 Documentation:
   Enabled: false
 AllCops:
-  TargetRubyVersion: 2.2
+  TargetRubyVersion: 2.3
 
 Metrics/LineLength:
   Max: 100

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ sudo: false
 language: ruby
 cache: bundler
 rvm:
-  - 2.2.10
   - 2.3.7
   - 2.4.4
   - 2.5.1

--- a/example/Gemfile
+++ b/example/Gemfile
@@ -6,15 +6,15 @@ source 'https://rubygems.org'
 gem 'rake'
 
 # Component requirements
-gem 'haml'
-gem 'dm-sqlite-adapter'
-gem 'dm-validations'
-gem 'dm-timestamps'
-gem 'dm-migrations'
-gem 'dm-constraints'
 gem 'dm-aggregates'
-gem 'dm-types'
+gem 'dm-constraints'
 gem 'dm-core'
+gem 'dm-migrations'
+gem 'dm-sqlite-adapter'
+gem 'dm-timestamps'
+gem 'dm-types'
+gem 'dm-validations'
+gem 'haml'
 
 # Padrino Stable Gem
 gem 'padrino'

--- a/lib/u2f/client_data.rb
+++ b/lib/u2f/client_data.rb
@@ -5,8 +5,8 @@ module U2F
   # A representation of ClientData, chapter 7
   # http://fidoalliance.org/specs/fido-u2f-raw-message-formats-v1.0-rd-20141008.pdf
   class ClientData
-    REGISTRATION_TYP   = 'navigator.id.finishEnrollment'.freeze
-    AUTHENTICATION_TYP = 'navigator.id.getAssertion'.freeze
+    REGISTRATION_TYP   = 'navigator.id.finishEnrollment'
+    AUTHENTICATION_TYP = 'navigator.id.getAssertion'
 
     attr_accessor :typ, :challenge, :origin
     alias type typ

--- a/lib/u2f/fake_u2f.rb
+++ b/lib/u2f/fake_u2f.rb
@@ -3,7 +3,7 @@
 module U2F
   # This class is for mocking a U2F device for testing purposes.
   class FakeU2F
-    CURVE_NAME = 'prime256v1'.freeze
+    CURVE_NAME = 'prime256v1'
 
     attr_accessor :app_id, :counter, :key_handle_raw, :cert_subject
 

--- a/lib/version.rb
+++ b/lib/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module U2F
-  VERSION = '1.0.0'.freeze
+  VERSION = '1.0.0'
 end

--- a/u2f.gemspec
+++ b/u2f.gemspec
@@ -13,7 +13,7 @@ Gem::Specification.new do |s|
   s.email       = ['brissmyr@gmail.com', 'sebastian.wallin@gmail.com']
   s.homepage    = 'https://github.com/castle/ruby-u2f'
   s.license     = 'MIT'
-  s.required_ruby_version = '>= 2.2.0'
+  s.required_ruby_version = '>= 2.3'
 
   s.files       = Dir['{lib}/**/*'] + ['README.md', 'LICENSE']
   s.test_files  = Dir['spec/**/*']


### PR DESCRIPTION
Support for ruby 2.2 ended on March 31, 2018.

https://www.ruby-lang.org/en/news/2018/06/20/support-of-ruby-2-2-has-ended/