### PR TITLE
Add missing version field to FakeU2F#register_response

### DIFF
--- a/lib/u2f/fake_u2f.rb
+++ b/lib/u2f/fake_u2f.rb
@@ -37,7 +37,8 @@ module U2F
         client_data_json = client_data(::U2F::ClientData::REGISTRATION_TYP, challenge)
         JSON.dump(
           registrationData: reg_registration_data(client_data_json),
-          clientData: ::U2F.urlsafe_encode64(client_data_json)
+          clientData: ::U2F.urlsafe_encode64(client_data_json),
+          version: 'U2F_V2'
         )
       end
     end


### PR DESCRIPTION
[Here's](https://fidoalliance.org/specs/fido-u2f-v1.2-ps-20170411/fido-u2f-javascript-api-v1.2-ps-20170411.html#dictionary-registerresponse-members) the relevant section of the spec.